### PR TITLE
debian repository instructions improvements

### DIFF
--- a/files/index.html.tt2
+++ b/files/index.html.tt2
@@ -58,12 +58,12 @@ Signed-By: 05483D2F0A254E5BC12AC73021E0CA38EA2EA4AB</pre>
 	
 	<pre class="rahmen">
 Package: *
-Pin: release suite=grml-stable
-Pin-Priority: 1
+Pin: release a=grml-stable
+Pin-Priority: 100
 
 Package: *
-Pin: release suite=grml-testing
-Pin-Priority: 1</pre>
+Pin: release a=grml-testing
+Pin-Priority: 100</pre>
 
 	<p>Also  note that you may have trouble installing the <code>grml-debian-keyring</code> package as APT will complain about the missing key. A workaround is to download it directly:</p>
 	

--- a/files/index.html.tt2
+++ b/files/index.html.tt2
@@ -50,6 +50,7 @@
 Types: deb deb-src
 URIs: http://deb.grml.org/
 Suites: grml-stable grml-testing
+Architectures: i386 amd64
 Components: main
 Signed-By: 05483D2F0A254E5BC12AC73021E0CA38EA2EA4AB</pre>
 

--- a/files/index.html.tt2
+++ b/files/index.html.tt2
@@ -54,7 +54,7 @@ Architectures: i386 amd64
 Components: main
 Signed-By: 05483D2F0A254E5BC12AC73021E0CA38EA2EA4AB</pre>
 
-	<p>Then the following preferences file will keep packages from GRML to replace normal Debian packages:</p>
+	<p>Then the following <a href="https://manpages.debian.org/apt_preferences">preferences file</a> will keep packages from GRML to replace normal Debian packages, in <code>/etc/apt/preferences.d/grml.pref</code>:</p>
 	
 	<pre class="rahmen">
 Package: *

--- a/files/index.html.tt2
+++ b/files/index.html.tt2
@@ -44,6 +44,26 @@
 #  deb     http://deb.grml.org/ grml-testing main
 #  deb-src http://deb.grml.org/ grml-testing main</pre>
 
+	<p>If you are running Debian stretch or later, you may want to use the following <code>.sources</code> file, which will enforce the suite name and signing keys:</p>
+
+	<pre class="rahmen">
+Types: deb deb-src
+URIs: http://deb.grml.org/
+Suites: grml-stable grml-testing
+Components: main
+Signed-By: 05483D2F0A254E5BC12AC73021E0CA38EA2EA4AB</pre>
+
+	<p>Then the following preferences file will keep packages from GRML to replace normal Debian packages:</p>
+	
+	<pre class="rahmen">
+Package: *
+Pin: release suite=grml-stable
+Pin-Priority: 1
+
+Package: *
+Pin: release suite=grml-testing
+Pin-Priority: 1</pre>
+
         <h2><a name="wallpapers"></a>Wallpapers and other media files provided by Grml</h2>
 
 	<p>Wallpapers, CD covers and similar media files are available in the

--- a/files/index.html.tt2
+++ b/files/index.html.tt2
@@ -65,6 +65,14 @@ Package: *
 Pin: release suite=grml-testing
 Pin-Priority: 1</pre>
 
+	<p>Also  note that you may have trouble installing the <code>grml-debian-keyring</code> package as APT will complain about the missing key. A workaround is to download it directly:</p>
+	
+	<pre class="rahmen">
+sudo wget -O /etc/apt/trusted.gpg.d/grml.gpg http://deb.grml.org/repo-key.gpg
+sudo apt-get update
+sudo apt-get install grml-debian-keyring
+</pre>
+
         <h2><a name="wallpapers"></a>Wallpapers and other media files provided by Grml</h2>
 
 	<p>Wallpapers, CD covers and similar media files are available in the


### PR DESCRIPTION
this change allows people to setup the Grml repositories without trusting them with base packages and will enforce the signature on the repository as well instead of trusting the upstream `grml-debian-archive` package which could be hijacked.

it also adds a preferences sample file and a way to install the keyring without downloading the package, which fails on stretch.