### PR TITLE
pull archive keyring out of global trust path

### DIFF
--- a/files/index.html.tt2
+++ b/files/index.html.tt2
@@ -52,7 +52,7 @@ URIs: http://deb.grml.org/
 Suites: grml-stable grml-testing
 Architectures: i386 amd64
 Components: main
-Signed-By: 05483D2F0A254E5BC12AC73021E0CA38EA2EA4AB</pre>
+Signed-By: /usr/share/keyrings/grml-archive-keyring.gpg</pre>
 
 	<p>Then the following <a href="https://manpages.debian.org/apt_preferences">preferences file</a> will keep packages from GRML to replace normal Debian packages, in <code>/etc/apt/preferences.d/grml.pref</code>:</p>
 	
@@ -68,7 +68,7 @@ Pin-Priority: 100</pre>
 	<p>Also  note that you may have trouble installing the <code>grml-debian-keyring</code> package as APT will complain about the missing key. A workaround is to download it directly:</p>
 	
 	<pre class="rahmen">
-sudo wget -O /etc/apt/trusted.gpg.d/grml.gpg http://deb.grml.org/repo-key.gpg
+sudo wget -O /usr/share/keyrings/grml-archive-keyring.gpg http://deb.grml.org/repo-key.gpg
 sudo apt-get update
 sudo apt-get install grml-debian-keyring
 </pre>


### PR DESCRIPTION
The [repository instructions](https://wiki.debian.org/RepositoryInstructions) have been changed to avoid writing third-party keyring files to the global trust anchors (in `/etc/apt/trusted-gpg.d`) and instead write those to a more neutral location (`/usr/share/keyrings`, alongside other keyring files).

The downside of this change is that the key fingerprint isn't validated directly through this process. But considering that validation of the key is anchored through HTTPS validation in the first place, we do not *really* lose anything by moving that to the `.gpg` file transfer: that file's integrity is still checked through HTTPS. Furthermore, not storing the explicit fingerprint here will make future key rotations easier as they will not require documentation updates.

Note that this change will also require a change in the `grml-debian-keyring` package to install the keyring file in the new location. If that package does not install a `.sources` or `.list` file, that move will also break existing configurations, so a NEWS entry might be in order as well.

This is a followup for #13.