### PR TITLE
faq: Gnackwatschn is not a facepalm

### DIFF
--- a/faq/index.html.tt2
+++ b/faq/index.html.tt2
@@ -119,7 +119,7 @@
 
         <p>Codename of Grml 2018.12 is "Gnackwatschn", which is
         an austrian and bavarian word, meaning "hit in the neck".
-	We consider this an alternative to a facepalm.
+	We consider this an alternative to a facepalm; although a "Gnackwatschn" isn't usually self-inflicted.
 
         <h3><a name="requirements"></a><a href="#toc">Requirements for running Grml</a></h3>
 


### PR DESCRIPTION
a Gnackwatschn isn't the same as facepalm. especially as it is not self-inflicted.