### PR TITLE
reverse the order of dd arguments to ease copy

### DIFF
--- a/download/index.html.tt2
+++ b/download/index.html.tt2
@@ -230,7 +230,7 @@
           <b>Boot from USB key</b><br />
           <br />
           Just <kbd>dd(1)</kbd> the downloaded ISO to an <abbr title="Any existing data will be overwritten by the dd command!">empty</abbr> USB key!<br /><br />
-          <code class="keyboard">dd bs=4M status=progress conv=fdatasync if=grml_2021.07.iso of=/dev/USB_KEY</code>
+          <code class="keyboard">dd bs=4M status=progress conv=fdatasync if=grml64-full_2021.07.iso of=/dev/USB_KEY</code>
           <br /><br />
 
           <b>Troubleshooting</b><br /><br />

--- a/download/index.html.tt2
+++ b/download/index.html.tt2
@@ -230,7 +230,7 @@
           <b>Boot from USB key</b><br />
           <br />
           Just <kbd>dd(1)</kbd> the downloaded ISO to an <abbr title="Any existing data will be overwritten by the dd command!">empty</abbr> USB key!<br /><br />
-          <code class="keyboard">dd if=grml_2021.07.iso of=/dev/USB_KEY bs=4M status=progress conv=fdatasync</code>
+          <code class="keyboard">dd bs=4M status=progress conv=fdatasync if=grml_2021.07.iso of=/dev/USB_KEY</code>
           <br /><br />
 
           <b>Troubleshooting</b><br /><br />


### PR DESCRIPTION
This is easier to copy-paste:

```
dd bs=4M status=progress conv=fdatasync if=grml_2021.07.iso of=/dev/USB_KEY
```

... because I can just paste it in a terminal and all I have to change is the last word. Compare with the previous version:

```
dd if=grml_2021.07.iso of=/dev/USB_KEY bs=4M status=progress conv=fdatasync
```

... where you have to paste, move your cursor right before ` bs` (notice the space), then change the word.

All that `bs=` and `conv=` is cosmetic anyways, keep the good stuff where it matters, near the end of line, where the cursor will be.