### PR TITLE
team: move Alexander 'formorer' Wirt from Active to Alumni

### DIFF
--- a/team/index.html.tt2
+++ b/team/index.html.tt2
@@ -29,7 +29,6 @@
             <h2>Grml Developers</h2>
 
             <ul>
-              <li>Alexander Wirt (formorer)</li>
               <li>Darshaka Pathirana (dpat)</li>
               <li>Frank Terbeck (ft)</li>
               <li>Michael Prokop (mika)</li>
@@ -39,6 +38,7 @@
 
             <ul>
               <li>Alexander Steinböck</li>
+              <li>Alexander Wirt</li>
               <li>Andreas Gredler</li>
               <li>Chris Hofstaedtler</li>
               <li>Evgeni Golov</li>


### PR DESCRIPTION
Thank you for all your support over the many years. We haven't received any contributions from you for a long time and are now setting your status to Alumni.

If you would like to actively contribute again, please reach out! :)

Thanks for everything!