### PR TITLE
Drop obsolete meta tag

### DIFF
--- a/beta/index.html.tt2
+++ b/beta/index.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/bugs/index.html.tt2
+++ b/bugs/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/bugs/known/index.html.tt2
+++ b/bugs/known/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://www.grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-0.3-small.html.tt2
+++ b/changelogs/README-0.3-small.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-0.7.html.tt2
+++ b/changelogs/README-0.7.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-0.8.html.tt2
+++ b/changelogs/README-0.8.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-0.9-rc1.html.tt2
+++ b/changelogs/README-0.9-rc1.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-0.9.html.tt2
+++ b/changelogs/README-0.9.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-1.0-rc1.html.tt2
+++ b/changelogs/README-grml-1.0-rc1.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-1.0.html.tt2
+++ b/changelogs/README-grml-1.0.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-1.1-rc1/index.html.tt2
+++ b/changelogs/README-grml-1.1-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-1.1/index.html.tt2
+++ b/changelogs/README-grml-1.1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2008.11/index.html.tt2
+++ b/changelogs/README-grml-2008.11/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2009.05/index.html.tt2
+++ b/changelogs/README-grml-2009.05/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2009.10/index.html.tt2
+++ b/changelogs/README-grml-2009.10/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2010.04/index.html.tt2
+++ b/changelogs/README-grml-2010.04/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2010.12-rc0/index.html.tt2
+++ b/changelogs/README-grml-2010.12-rc0/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2010.12/index.html.tt2
+++ b/changelogs/README-grml-2010.12/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2011-04/index.html.tt2
+++ b/changelogs/README-grml-2011-04/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2011.05-rc1/index.html.tt2
+++ b/changelogs/README-grml-2011.05-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2011.05/index.html.tt2
+++ b/changelogs/README-grml-2011.05/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2011.12-rc1/index.html.tt2
+++ b/changelogs/README-grml-2011.12-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2011.12/index.html.tt2
+++ b/changelogs/README-grml-2011.12/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2012.05-rc1/index.html.tt2
+++ b/changelogs/README-grml-2012.05-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2012.05/index.html.tt2
+++ b/changelogs/README-grml-2012.05/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2013.02-rc1/index.html.tt2
+++ b/changelogs/README-grml-2013.02-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2013.02/index.html.tt2
+++ b/changelogs/README-grml-2013.02/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2013.09-rc1/index.html.tt2
+++ b/changelogs/README-grml-2013.09-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2013.09/index.html.tt2
+++ b/changelogs/README-grml-2013.09/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2014.03-rc1/index.html.tt2
+++ b/changelogs/README-grml-2014.03-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2014.03/index.html.tt2
+++ b/changelogs/README-grml-2014.03/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2014.10-rc1/index.html.tt2
+++ b/changelogs/README-grml-2014.10-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2014.11/index.html.tt2
+++ b/changelogs/README-grml-2014.11/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2017.05-rc1/index.html.tt2
+++ b/changelogs/README-grml-2017.05-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2017.05/index.html.tt2
+++ b/changelogs/README-grml-2017.05/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2018.12-rc1/index.html.tt2
+++ b/changelogs/README-grml-2018.12-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2018.12/index.html.tt2
+++ b/changelogs/README-grml-2018.12/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2020.06-rc1/index.html.tt2
+++ b/changelogs/README-grml-2020.06-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2020.06/index.html.tt2
+++ b/changelogs/README-grml-2020.06/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2021.07-rc1/index.html.tt2
+++ b/changelogs/README-grml-2021.07-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2021.07/index.html.tt2
+++ b/changelogs/README-grml-2021.07/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2022.11-rc1/index.html.tt2
+++ b/changelogs/README-grml-2022.11-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2022.11/index.html.tt2
+++ b/changelogs/README-grml-2022.11/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2024.02-rc1/index.html.tt2
+++ b/changelogs/README-grml-2024.02-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-2024.02/index.html.tt2
+++ b/changelogs/README-grml-2024.02/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-medium-0.1-rc1/index.html.tt2
+++ b/changelogs/README-grml-medium-0.1-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-medium-0.1/index.html.tt2
+++ b/changelogs/README-grml-medium-0.1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-medium-2008.11/index.html.tt2
+++ b/changelogs/README-grml-medium-2008.11/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-medium-2009.05/index.html.tt2
+++ b/changelogs/README-grml-medium-2009.05/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-medium-2009.10/index.html.tt2
+++ b/changelogs/README-grml-medium-2009.10/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-medium-2010.04/index.html.tt2
+++ b/changelogs/README-grml-medium-2010.04/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-small-0.4-rc1.html.tt2
+++ b/changelogs/README-grml-small-0.4-rc1.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-small-0.4.html.tt2
+++ b/changelogs/README-grml-small-0.4.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-small-2008.11/index.html.tt2
+++ b/changelogs/README-grml-small-2008.11/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-small-2009.05/index.html.tt2
+++ b/changelogs/README-grml-small-2009.05/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-small-2009.10/index.html.tt2
+++ b/changelogs/README-grml-small-2009.10/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml-small-2010.04/index.html.tt2
+++ b/changelogs/README-grml-small-2010.04/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-0.1-rc1.html.tt2
+++ b/changelogs/README-grml64-0.1-rc1.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-0.1.html.tt2
+++ b/changelogs/README-grml64-0.1.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-0.2-rc1/index.html.tt2
+++ b/changelogs/README-grml64-0.2-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-0.2/index.html.tt2
+++ b/changelogs/README-grml64-0.2/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-2008.11/index.html.tt2
+++ b/changelogs/README-grml64-2008.11/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-2009.05/index.html.tt2
+++ b/changelogs/README-grml64-2009.05/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-2009.10/index.html.tt2
+++ b/changelogs/README-grml64-2009.10/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-2010.04/index.html.tt2
+++ b/changelogs/README-grml64-2010.04/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-medium-0.1-rc1/index.html.tt2
+++ b/changelogs/README-grml64-medium-0.1-rc1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-medium-0.1/index.html.tt2
+++ b/changelogs/README-grml64-medium-0.1/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-medium-2008.11/index.html.tt2
+++ b/changelogs/README-grml64-medium-2008.11/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-medium-2009.05/index.html.tt2
+++ b/changelogs/README-grml64-medium-2009.05/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-medium-2009.10/index.html.tt2
+++ b/changelogs/README-grml64-medium-2009.10/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-medium-2010.04/index.html.tt2
+++ b/changelogs/README-grml64-medium-2010.04/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-small-2008.11/index.html.tt2
+++ b/changelogs/README-grml64-small-2008.11/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-small-2009.05/index.html.tt2
+++ b/changelogs/README-grml64-small-2009.05/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-small-2009.10/index.html.tt2
+++ b/changelogs/README-grml64-small-2009.10/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/README-grml64-small-2010.04/index.html.tt2
+++ b/changelogs/README-grml64-small-2010.04/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/changelogs/index.html.tt2
+++ b/changelogs/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/config/index.html.tt2
+++ b/config/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/contact/index.html.tt2
+++ b/contact/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/copyright/index.html.tt2
+++ b/copyright/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/daily/index.html
+++ b/daily/index.html
@@ -5,7 +5,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://daily.grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <meta http-equiv="content-Type" content="application/xhtml+xml; charset=iso-8859-1" />
 <link rel="home" href="https://grml.org/" title="grml.org" />

--- a/docs/index.html.tt2
+++ b/docs/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/donations/index.html.tt2
+++ b/donations/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index, nofollow" />
 <meta name="Language" content="english, german" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/donations/index2.html.tt2
+++ b/donations/index2.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english, german" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/download/index.html.tt2
+++ b/download/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />
 <link rel="author" href="/team/" title="Team" />

--- a/download/mirrors/index.html.tt2
+++ b/download/mirrors/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/download/prerelease/index.html.tt2
+++ b/download/prerelease/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />
 <link rel="author" href="/team/" title="Team" />

--- a/errors/404.html
+++ b/errors/404.html
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow">
 <meta name="Language" content="english">
 <meta name="identifier-url" content="http://grml.org/errors/404.html">
-<meta name="MSSmartTagsPreventParsing" content="true">
 <style type="text/css">
 body {font-family: Verdana, Arial, Helvetica, sans-serif; color: #333333}
 a {color: #333333} 

--- a/errors/404/index.html
+++ b/errors/404/index.html
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow">
 <meta name="Language" content="english">
 <meta name="identifier-url" content="http://grml.org/errors/404/">
-<meta name="MSSmartTagsPreventParsing" content="true">
 <style type="text/css">
 body {font-family: Verdana, Arial, Helvetica, sans-serif; color: #333333}
 a {color: #333333}

--- a/errors/index.html
+++ b/errors/index.html
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow">
 <meta name="Language" content="german">
 <meta name="identifier-url" content="http://www.michael-prokop.at/">
-<meta name="MSSmartTagsPreventParsing" content="true">
 <meta http-equiv="imagetoolbar" content="no">
 </head>
 

--- a/faq/0.5.html.tt2
+++ b/faq/0.5.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/0.6.html.tt2
+++ b/faq/0.6.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/0.7.html.tt2
+++ b/faq/0.7.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/0.8.html.tt2
+++ b/faq/0.8.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/0.9.html.tt2
+++ b/faq/0.9.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/1.0.html.tt2
+++ b/faq/1.0.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/1.1.html.tt2
+++ b/faq/1.1.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/2008.11.html.tt2
+++ b/faq/2008.11.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/2009.05.html.tt2
+++ b/faq/2009.05.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/2009.10.html.tt2
+++ b/faq/2009.10.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/2010.04.html.tt2
+++ b/faq/2010.04.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/2010.12.html.tt2
+++ b/faq/2010.12.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/2011.05.html.tt2
+++ b/faq/2011.05.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/2012.05.html.tt2
+++ b/faq/2012.05.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/faq/index.html.tt2
+++ b/faq/index.html.tt2
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/features/index.html.tt2
+++ b/features/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="Features" />

--- a/files/README-0.3-small.html.tt2
+++ b/files/README-0.3-small.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/files/README-0.7.html.tt2
+++ b/files/README-0.7.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/files/README-0.8.html.tt2
+++ b/files/README-0.8.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/files/README-0.9-rc1.html.tt2
+++ b/files/README-0.9-rc1.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/files/README-0.9.html.tt2
+++ b/files/README-0.9.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/files/README-grml-1.0-rc1.html.tt2
+++ b/files/README-grml-1.0-rc1.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/files/README-grml-1.0.html.tt2
+++ b/files/README-grml-1.0.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/files/README-grml-small-0.4-rc1.html.tt2
+++ b/files/README-grml-small-0.4-rc1.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/files/README-grml-small-0.4.html.tt2
+++ b/files/README-grml-small-0.4.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/files/README-grml64-0.1-rc1.html.tt2
+++ b/files/README-grml64-0.1-rc1.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/files/README-grml64-0.1.html.tt2
+++ b/files/README-grml64-0.1.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/files/index.html.tt2
+++ b/files/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/history/index.html.tt2
+++ b/history/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/index.html.tt2
+++ b/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/ppc/index.html.tt2
+++ b/ppc/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/press/index.html.tt2
+++ b/press/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/qemu/index.html.tt2
+++ b/qemu/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/reports/devmeeting_2010/index.html.tt2
+++ b/reports/devmeeting_2010/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/reports/index.html
+++ b/reports/index.html
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/screenshots/index.html.tt2
+++ b/screenshots/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/small/index.html.tt2
+++ b/small/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/sponsors/index.html.tt2
+++ b/sponsors/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/survey2011-results/index.html.tt2
+++ b/survey2011-results/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/survey2011/old.html.tt2
+++ b/survey2011/old.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/team/index.html.tt2
+++ b/team/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/terminalserver/index.html.tt2
+++ b/terminalserver/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/tips/index.html
+++ b/tips/index.html
@@ -9,7 +9,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/who-is-using/index.html.tt2
+++ b/who-is-using/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="http://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/zsh/index.html.tt2
+++ b/zsh/index.html.tt2
@@ -10,7 +10,6 @@
 <meta name="Robots" content="index,follow" />
 <meta name="Language" content="english" />
 <meta name="identifier-url" content="https://grml.org/" />
-<meta name="MSSmartTagsPreventParsing" content="true" />
 <meta http-equiv="imagetoolbar" content="no" />
 <link rel="home" href="/" title="grml.org" />
 <link rel="help" href="/features/" title="About" />

--- a/zsh/tools_zsh_en.html
+++ b/zsh/tools_zsh_en.html
@@ -11,7 +11,6 @@
 <meta name="Robots" content="index,follow">
 <meta name="Language" content="english">
 <meta name="identifier-url" content="http://www.michael-prokop.at/">
-<meta name="MSSmartTagsPreventParsing" content="true">
 <meta http-equiv="imagetoolbar" content="no">
 <link rel="stylesheet" href="/style.css" type="text/css">
 </head>

--- a/zsh/tools_zsh_liebhaber.html
+++ b/zsh/tools_zsh_liebhaber.html
@@ -11,7 +11,6 @@
 <meta name="Robots" content="index,follow">
 <meta name="Language" content="german">
 <meta name="identifier-url" content="http://www.michael-prokop.at/">
-<meta name="MSSmartTagsPreventParsing" content="true">
 <meta http-equiv="imagetoolbar" content="no">
 <link rel="stylesheet" href="/style.css" type="text/css">
 </head>


### PR DESCRIPTION
Apparently became obsolete before IE6 final was released.