### PR TITLE
changelogs: reword list of all Grml releases

### DIFF
--- a/content/changelogs/_index.md
+++ b/content/changelogs/_index.md
@@ -15,7 +15,7 @@ icon = 'changelog'
 
 {{%/ if_have_prerelease %}}
 
-## Previous releases
+## List of Grml releases
 
 {{< require_release_update "2024.12" >}}
 * <a href="README-grml-2024.12/">Grml 2024.12</a> - codename Adventgrenze


### PR DESCRIPTION
changelogs: reword list of all Grml releases

Currently it reads:

```
Current release

Release announcement for Grml 2024.12 - codename Adventgrenze

Previous releases

* Grml 2024.12 - codename Adventgrenze
* Grml 2024.02 - codename Glumpad
* Grml 2022.11 - codename MalGuckes
* Grml 2021.07 - codename JauKerl
* Grml 2020.06 - codename Ausgehfuahangl
* Grml 2018.12 - codename Gnackwatschn
* Grml 2017.05 - codename Freedatensuppe
* Grml 2014.11 - codename Gschistigschasti
[...]
```

So the current version is listed twice, though getting rid of the current list in the list for "Previous releases" probably isn't worth it, given that it's actually nice to have a consistent list of all our releases in the same format/schema, e.g. for c/p. So reword `Previous releases` accordingly.
