### PR TITLE
Code highlight each line starting with % or #

### DIFF
--- a/content/tips/index.md
+++ b/content/tips/index.md
@@ -15,7 +15,14 @@ layout = 'tips'
 <a name="{{ $number }}"></a>
 Grml Tip Number {{ $number }}<br>
 {{ $tip := . -}}
-<pre>{{ htmlEscape $tip -}}</pre>
+{{- range (split (strings.TrimSuffix "\n" $tip) "\n") -}}
+{{ $code := . -}}
+{{- if or (strings.Contains $code "#") (strings.Contains $code "%") -}}
+{{ highlight $code "shell" }}
+{{- else -}}
+<pre>{{ htmlEscape $code }}</pre>
+{{- end -}}
+{{- end -}}
 <hr>
 {{ $number = add $number 1 }}
 


### PR DESCRIPTION
It took me quite a while to come up with these few lines as I am absolutely not into Hugo shortcodes / layouts /  templates...

Things which could be improved:
- lines starting with "#" look like commented out lines.
- Consecutive lines should be a block

Any other improvements? What do you think, @zeha 
 
See: grml/grml.org#73