### PR TITLE
team: update list of alumni developers

### DIFF
--- a/content/team/index.md
+++ b/content/team/index.md
@@ -14,12 +14,17 @@ title = 'The Grml Team'
 * Alexander Steinböck
 * Alexander Wirt
 * Andreas Gredler
+* Daniel K. Gebhart
 * Evgeni Golov
+* Julius Plenz
 * Marcel Wichern
+* Mario Lang
 * Markus Rekkenbeil
+* Martin Hecher
 * Matthias Kopfermann
 * Michael Gebetsroither
 * Moritz Augsburger
+* Nico Golde
 * Rhonda D'Vine
 * Timo Boettcher
 * Tobias Klauser


### PR DESCRIPTION
It looks like I did a poor job with maintaining that list, but when researching the time since 2003, noticed we had further alumnis!