### PR TITLE
Add links to grml-tips in documentation and faq page

### DIFF
--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -10,7 +10,7 @@ If you are looking for information on the Zsh take a look at the <a href="/zsh/"
 
 The available boot options are documented at <a href="/cheatcodes/">the cheatcodes webpage</a>.
 
-Many tips and tricks can be found in the <a href="https://wiki.grml.org/">grml-wiki (wiki.grml.org)</a>.
+Many tips and tricks can be found in the <a href="https://wiki.grml.org/">grml-wiki (wiki.grml.org)</a> and in <a href="/tips/">grml-tips</a>.
 
 ## Guides
 

--- a/content/faq/_index.md
+++ b/content/faq/_index.md
@@ -304,7 +304,7 @@ Bash is largely a subset of Zsh and you don't have to throw away your knowledge 
 
 Do you have a question which is not answered in the FAQ or in the provided
 [documentation](/docs/) (execute `grml-info` on your Grml system for offline
-documentation)?  Also check out `grml-tips $KEYWORD` on your Grml system.
+documentation)? Also check out `grml-tips $KEYWORD` on your Grml system or [online](/tips/).
 
 Take a look at both our website and the [wiki](https://github.com/grml/grml/wiki).
 A good place to become part of the community is the [Grml mailinglist](/mailinglist/).


### PR DESCRIPTION
grml-tips needs some love and are hard to find.

Added links to grml-tips in the documentation and faq page to create more visibilty.

Issue: grml/grml-tips#6