### PR TITLE
Make grml.org/tips start with 1

### DIFF
--- a/content/tips/index.md
+++ b/content/tips/index.md
@@ -6,7 +6,7 @@ layout = 'tips'
 
 {{ $url := "https://raw.githubusercontent.com/grml/grml-tips/refs/heads/master/grml_tips" }}
 {{ $s := slice }}
-{{ $number := 0 }}
+{{ $number := 1 }}
 {{ with try (resources.GetRemote $url) }}
   {{ with .Err }}
     {{ errorf "%s" . }}


### PR DESCRIPTION
In grml/grml-tips#8 we made some adjustments to make grml-tips start the numbering with 1:

```
  ❯ grep -e "^-- " -A1 grml_tips | grep -v -- "^--" | cat -n | head
       1  Configure network:
       2  Deactivate error correction of zsh:
       3  Disable automatic setting of title in GNU screen:
       4  Do not use menu completion in zsh:
       5  Run GNU screen with grml-configuration:
       6  Print out grml-version:
       7  Configure mutt:
       8  Use encrypted files / partitions:
       9  Change resolution of X:
      10  Change resolution of framebuffer:
```

We missed to adjust our website: https://grml.org/tips started its numbering with 0.

Issue: grml/grml-tips#8