### PR TITLE
Update URLs for mailing lists which got migrated to mailman 3 + hyperkitty

### DIFF
--- a/content/changelogs/README-grml-2010.04/index.md
+++ b/content/changelogs/README-grml-2010.04/index.md
@@ -265,7 +265,7 @@ usb-modeswitch usb-modeswitch-data xz-utils zerofree
 <ul>
 
 <li>Grml <a href="http://grml.supersized.org/archives/336-Grml-goes-microblogging.html">goes microblogging</a>.</li>
-<li>New <a href="http://ml.grml.org/mailman/listinfo/grml-devel">Grml developer mailinglist</a>.</li>
+<li>New <a href="http://ml.grml.org/postorius/lists/grml-devel.ml.grml.org">Grml developer mailinglist</a>.</li>
 
 </ul>
 

--- a/content/changelogs/README-grml-2011.12-rc1/index.md
+++ b/content/changelogs/README-grml-2011.12-rc1/index.md
@@ -155,5 +155,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2011.12/index.md
+++ b/content/changelogs/README-grml-2011.12/index.md
@@ -163,5 +163,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2012.05-rc1/index.md
+++ b/content/changelogs/README-grml-2012.05-rc1/index.md
@@ -137,5 +137,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2012.05/index.md
+++ b/content/changelogs/README-grml-2012.05/index.md
@@ -131,5 +131,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2013.02-rc1/index.md
+++ b/content/changelogs/README-grml-2013.02-rc1/index.md
@@ -157,5 +157,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2013.02/index.md
+++ b/content/changelogs/README-grml-2013.02/index.md
@@ -159,5 +159,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2013.09-rc1/index.md
+++ b/content/changelogs/README-grml-2013.09-rc1/index.md
@@ -146,5 +146,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2013.09/index.md
+++ b/content/changelogs/README-grml-2013.09/index.md
@@ -147,5 +147,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2014.03-rc1/index.md
+++ b/content/changelogs/README-grml-2014.03-rc1/index.md
@@ -129,5 +129,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2014.03/index.md
+++ b/content/changelogs/README-grml-2014.03/index.md
@@ -128,5 +128,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2014.10-rc1/index.md
+++ b/content/changelogs/README-grml-2014.10-rc1/index.md
@@ -147,5 +147,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2014.11/index.md
+++ b/content/changelogs/README-grml-2014.11/index.md
@@ -153,5 +153,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="http://wiki.grml.org/">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2017.05-rc1/index.md
+++ b/content/changelogs/README-grml-2017.05-rc1/index.md
@@ -258,5 +258,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="https://github.com/grml/grml/wiki">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2017.05/index.md
+++ b/content/changelogs/README-grml-2017.05/index.md
@@ -292,5 +292,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="https://github.com/grml/grml/wiki">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2018.12-rc1/index.md
+++ b/content/changelogs/README-grml-2018.12-rc1/index.md
@@ -234,5 +234,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="https://github.com/grml/grml/wiki">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2018.12/index.md
+++ b/content/changelogs/README-grml-2018.12/index.md
@@ -232,5 +232,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="https://github.com/grml/grml/wiki">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2020.06-rc1/index.md
+++ b/content/changelogs/README-grml-2020.06-rc1/index.md
@@ -244,5 +244,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="https://github.com/grml/grml/wiki">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2020.06/index.md
+++ b/content/changelogs/README-grml-2020.06/index.md
@@ -247,5 +247,5 @@ href="/contact/#irc">IRC channel</a>, and <a
 href="https://github.com/grml/grml/wiki">wiki</a>.
 
 <p>To sign up for future Grml announcements, please subscribe to <a
-href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's
+href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's
 announcement list</a>.</p>

--- a/content/changelogs/README-grml-2021.07-rc1/index.md
+++ b/content/changelogs/README-grml-2021.07-rc1/index.md
@@ -175,4 +175,4 @@ for their contributions.</p>
 <h3>More Information</h3>
 
 <p>You can find out more about Grml on <a href="/">our website</a>, <a href="/contact/#irc">IRC channel</a>, and <a href="https://github.com/grml/grml/wiki">wiki</a>.
-<p>To sign up for future Grml announcements, please subscribe to <a href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's announcement list</a> or follow our <a href="https://blog.grml.org/">blog</a>.</p>
+<p>To sign up for future Grml announcements, please subscribe to <a href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's announcement list</a> or follow our <a href="https://blog.grml.org/">blog</a>.</p>

--- a/content/changelogs/README-grml-2021.07/index.md
+++ b/content/changelogs/README-grml-2021.07/index.md
@@ -174,4 +174,4 @@ for their contributions.</p>
 <h3>More Information</h3>
 
 <p>You can find out more about Grml on <a href="/">our website</a>, <a href="/contact/#irc">IRC channel</a>, and <a href="https://github.com/grml/grml/wiki">wiki</a>.
-<p>To sign up for future Grml announcements, please subscribe to <a href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's announcement list</a> or follow our <a href="https://blog.grml.org/">blog</a>.</p>
+<p>To sign up for future Grml announcements, please subscribe to <a href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's announcement list</a> or follow our <a href="https://blog.grml.org/">blog</a>.</p>

--- a/content/changelogs/README-grml-2022.11-rc1/index.md
+++ b/content/changelogs/README-grml-2022.11-rc1/index.md
@@ -187,5 +187,5 @@ for their contributions.</p>
 
 <p>You can find out more about Grml on <a href="/">our website</a>, <a href="/contact/#irc">IRC channel</a>, and <a href="https://github.com/grml/grml/wiki">wiki</a>.
 
-<p>To sign up for future Grml announcements, please subscribe to <a href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's announcement list</a> or
+<p>To sign up for future Grml announcements, please subscribe to <a href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's announcement list</a> or
 follow our <a href="https://blog.grml.org/">blog</a>.</p>

--- a/content/changelogs/README-grml-2022.11/index.md
+++ b/content/changelogs/README-grml-2022.11/index.md
@@ -184,5 +184,5 @@ for their contributions.</p>
 
 <p>You can find out more about Grml on <a href="/">our website</a>, <a href="/contact/#irc">IRC channel</a>, and <a href="https://github.com/grml/grml/wiki">wiki</a>.
 
-<p>To sign up for future Grml announcements, please subscribe to <a href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's announcement list</a> or
+<p>To sign up for future Grml announcements, please subscribe to <a href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's announcement list</a> or
 follow our <a href="https://blog.grml.org/">blog</a>.</p>

--- a/content/changelogs/README-grml-2024.02-rc1/index.md
+++ b/content/changelogs/README-grml-2024.02-rc1/index.md
@@ -145,5 +145,5 @@ for their contributions.</p>
 
 <p>You can find out more about Grml on <a href="/">our website</a>, <a href="/contact/#irc">IRC channel</a>, and <a href="https://github.com/grml/grml/wiki">wiki</a>.
 
-<p>To sign up for future Grml announcements, please subscribe to <a href="http://ml.grml.org/mailman/listinfo/grml-announce">Grml's announcement list</a> or
+<p>To sign up for future Grml announcements, please subscribe to <a href="http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org">Grml's announcement list</a> or
 follow our <a href="https://blog.grml.org/">blog</a>.</p>

--- a/content/changelogs/README-grml-2024.02/index.md
+++ b/content/changelogs/README-grml-2024.02/index.md
@@ -133,4 +133,4 @@ for their contributions.
 
 You can find out more about Grml on [our website](/), [IRC channel](/contact/#irc), and the [wiki](https://github.com/grml/grml/wiki).
 
-To sign up for future Grml announcements, please subscribe to [Grml's announcement list](http://ml.grml.org/mailman/listinfo/grml-announce) or follow our [blog](https://blog.grml.org/).
+To sign up for future Grml announcements, please subscribe to [Grml's announcement list](http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org) or follow our [blog](https://blog.grml.org/).

--- a/content/changelogs/README-grml-2024.12/index.md
+++ b/content/changelogs/README-grml-2024.12/index.md
@@ -185,4 +185,4 @@ We would like to thank [netcup](https://www.netcup.com/) for their financial con
 
 You can find out more about Grml on [our website](/), [IRC channel](/contact/#irc), and the [wiki](https://github.com/grml/grml/wiki).
 
-To sign up for future Grml announcements, please subscribe to [Grml's announcement list](http://ml.grml.org/mailman/listinfo/grml-announce) or follow our [blog](https://blog.grml.org/).
+To sign up for future Grml announcements, please subscribe to [Grml's announcement list](http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org) or follow our [blog](https://blog.grml.org/).

--- a/content/changelogs/README-grml-2025.05/index.md
+++ b/content/changelogs/README-grml-2025.05/index.md
@@ -223,4 +223,4 @@ Thanks to everyone who contributed to Grml and this release, stay healthy and ha
 
 You can find out more about Grml on [our website](/), [IRC channel](/contact/#irc), and the [wiki](https://github.com/grml/grml/wiki).
 
-To sign up for future Grml announcements, please subscribe to [Grml's announcement list](http://ml.grml.org/mailman/listinfo/grml-announce) or follow our [blog](https://blog.grml.org/).
+To sign up for future Grml announcements, please subscribe to [Grml's announcement list](http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org) or follow our [blog](https://blog.grml.org/).

--- a/content/changelogs/README-grml-2025.08/index.md
+++ b/content/changelogs/README-grml-2025.08/index.md
@@ -147,4 +147,4 @@ Thanks to everyone who contributed to Grml and this release, stay healthy and ha
 
 You can find out more about Grml on [our website](/), [IRC channel](/contact/#irc), and the [wiki](https://github.com/grml/grml/wiki).
 
-To sign up for future Grml announcements, please subscribe to [Grml's announcement list](http://ml.grml.org/mailman/listinfo/grml-announce) or follow our [blog](https://blog.grml.org/).
+To sign up for future Grml announcements, please subscribe to [Grml's announcement list](http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org) or follow our [blog](https://blog.grml.org/).

--- a/content/changelogs/README-grml-medium-2010.04/index.md
+++ b/content/changelogs/README-grml-medium-2010.04/index.md
@@ -257,7 +257,7 @@ ufsutils zerofree
 <ul>
 
 <li>Grml <a href="http://grml.supersized.org/archives/336-Grml-goes-microblogging.html">goes microblogging</a>.</li>
-<li>New <a href="http://ml.grml.org/mailman/listinfo/grml-devel">Grml developer mailinglist</a>.</li>
+<li>New <a href="http://ml.grml.org/postorius/lists/grml-devel.ml.grml.org">Grml developer mailinglist</a>.</li>
 
 </ul>
 

--- a/content/changelogs/README-grml-small-2010.04/index.md
+++ b/content/changelogs/README-grml-small-2010.04/index.md
@@ -205,7 +205,7 @@ jfsutils kexec-tools mksh slsh ufsutils
 <ul>
 
 <li>Grml <a href="http://grml.supersized.org/archives/336-Grml-goes-microblogging.html">goes microblogging</a>.</li>
-<li>New <a href="http://ml.grml.org/mailman/listinfo/grml-devel">Grml developer mailinglist</a>.</li>
+<li>New <a href="http://ml.grml.org/postorius/lists/grml-devel.ml.grml.org">Grml developer mailinglist</a>.</li>
 
 </ul>
 

--- a/content/changelogs/README-grml64-2010.04/index.md
+++ b/content/changelogs/README-grml64-2010.04/index.md
@@ -277,7 +277,7 @@ zerofree
 <ul>
 
 <li>Grml <a href="http://grml.supersized.org/archives/336-Grml-goes-microblogging.html">goes microblogging</a>.</li>
-<li>New <a href="http://ml.grml.org/mailman/listinfo/grml-devel">Grml developer mailinglist</a>.</li>
+<li>New <a href="http://ml.grml.org/postorius/lists/grml-devel.ml.grml.org">Grml developer mailinglist</a>.</li>
 
 </ul>
 

--- a/content/changelogs/README-grml64-medium-2010.04/index.md
+++ b/content/changelogs/README-grml64-medium-2010.04/index.md
@@ -259,7 +259,7 @@ ufsutils zerofree
 <ul>
 
 <li>Grml <a href="http://grml.supersized.org/archives/336-Grml-goes-microblogging.html">goes microblogging</a>.</li>
-<li>New <a href="http://ml.grml.org/mailman/listinfo/grml-devel">Grml developer mailinglist</a>.</li>
+<li>New <a href="http://ml.grml.org/postorius/lists/grml-devel.ml.grml.org">Grml developer mailinglist</a>.</li>
 
 </ul>
 

--- a/content/changelogs/README-grml64-small-2010.04/index.md
+++ b/content/changelogs/README-grml64-small-2010.04/index.md
@@ -205,7 +205,7 @@ jfsutils kexec-tools mksh slsh ufsutils
 <ul>
 
 <li>Grml <a href="http://grml.supersized.org/archives/336-Grml-goes-microblogging.html">goes microblogging</a>.</li>
-<li>New <a href="http://ml.grml.org/mailman/listinfo/grml-devel">Grml developer mailinglist</a>.</li>
+<li>New <a href="http://ml.grml.org/postorius/lists/grml-devel.ml.grml.org">Grml developer mailinglist</a>.</li>
 
 </ul>
 

--- a/content/contact/index.md
+++ b/content/contact/index.md
@@ -14,9 +14,9 @@ For commercial support and services please send us mail to `business (at) grml.o
 ## Mailing lists
 {{< anchor mailinglist >}}
 
-If you want to be notified when a **new Grml release** is available, subscribe to the read-only [Grml announce mailing list](http://ml.grml.org/mailman/listinfo/grml-announce).
+If you want to be notified when a **new Grml release** is available, subscribe to the read-only [Grml announce mailing list](http://ml.grml.org/postorius/lists/grml-announce.ml.grml.org).
 
-If you want to participate in the **user mailing list of Grml**, please subscribe to the [Grml user mailing list](http://ml.grml.org/mailman/listinfo/grml).
+If you want to participate in the **user mailing list of Grml**, please subscribe to the [Grml user mailing list](http://ml.grml.org/postorius/lists/grml.ml.grml.org).
 Anyone can post to this mailing list, but if you are not already subscribed, your message will need moderator approval before being posted.
 This way we limit the amount of spam that makes it to the list.
 The Grml user mailing list is also available via NNTP on [gmane.io](https://gmane.io/).

--- a/content/history/index.md
+++ b/content/history/index.md
@@ -115,7 +115,7 @@ details...</a>.</p>
 
 <h3>13.02.2010</h3>
 
-<p>New <a href="http://ml.grml.org/mailman/listinfo/grml-devel">Grml developer mailinglist</a>.</p>
+<p>New <a href="http://ml.grml.org/postorius/lists/grml-devel.ml.grml.org">Grml developer mailinglist</a>.</p>
 
 <h2>2009</h2>
 


### PR DESCRIPTION
mur.at migrated from old mailman to mailman 3 + hyperkitty, so our archive URLs no longer work, but also the main mailing list URLs changed.

For example http://ml.grml.org/mailman/listinfo/grml used to redirect to https://lists.mur.at/mailman/listinfo/grml, which no longer exists as such now.

The new URL is https://lists.mur.at/postorius/lists/grml.ml.grml.org/ (for the Grml user mailing list), adjust URLs accordingly.