### PR TITLE
Adjust URL for grml-cheatcodes.txt for new grml-live layout

### DIFF
--- a/content/changelogs/README-grml-2008.11/index.md
+++ b/content/changelogs/README-grml-2008.11/index.md
@@ -121,7 +121,7 @@ screenshot</a>)
 option (thanks to Michael Holzt and Marc Haber)</li>
 
 <li>(re-)implemented <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 isofrom and tohd bootoptions</a></li>
 
 <li>moved from syslog-ng to rsyslog</li>

--- a/content/changelogs/README-grml-medium-2008.11/index.md
+++ b/content/changelogs/README-grml-medium-2008.11/index.md
@@ -129,7 +129,7 @@ screenshot</a>)
 option (thanks to Michael Holzt and Marc Haber)</li>
 
 <li>(re-)implemented <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 isofrom and tohd bootoptions</a></li>
 
 <li>moved from syslog-ng to rsyslog</li>

--- a/content/changelogs/README-grml-small-2008.11/index.md
+++ b/content/changelogs/README-grml-small-2008.11/index.md
@@ -106,7 +106,7 @@ screenshot</a>)
 option (thanks to Michael Holzt and Marc Haber)</li>
 
 <li>(re-)implemented <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 isofrom and tohd bootoptions</a></li>
 
 <li>moved from syslog-ng to rsyslog</li>

--- a/content/changelogs/README-grml64-2008.11/index.md
+++ b/content/changelogs/README-grml64-2008.11/index.md
@@ -127,7 +127,7 @@ screenshot</a>)
 option (thanks to Michael Holzt and Marc Haber)</li>
 
 <li>(re-)implemented <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 isofrom and tohd bootoptions</a></li>
 
 <li>moved from syslog-ng to rsyslog</li>

--- a/content/changelogs/README-grml64-medium-2008.11/index.md
+++ b/content/changelogs/README-grml64-medium-2008.11/index.md
@@ -129,7 +129,7 @@ screenshot</a>)
 option (thanks to Michael Holzt and Marc Haber)</li>
 
 <li>(re-)implemented <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 isofrom and tohd bootoptions</a></li>
 
 <li>moved from syslog-ng to rsyslog</li>

--- a/content/download/_index.md
+++ b/content/download/_index.md
@@ -182,7 +182,7 @@ document.getElementById('download_group1_noscript').style.display = 'none';
   <code class="keyboard">dd bs=4M status=progress conv=fdatasync if=grml-full-{{< param current_release.version >}}-amd64.iso of=/dev/USB_KEY</code>
   <br /><br />
   <b>Troubleshooting</b><br /><br />
-  <a href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">Boot option guide</a>
+  <a href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">Boot option guide</a>
   <br />
   <br />
   <br />

--- a/content/download/prerelease/index.md
+++ b/content/download/prerelease/index.md
@@ -186,7 +186,7 @@ document.getElementById('download_group1_noscript').style.display = 'none';
   <code class="keyboard">dd bs=4M status=progress conv=fdatasync if=grml-full-{{< param_opt current_prerelease.version >}}-amd64.iso of=/dev/USB_KEY</code>
   <br /><br />
   <b>Troubleshooting</b><br /><br />
-  <a href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">Boot option guide</a>
+  <a href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">Boot option guide</a>
   <br />
   <br />
   <br />

--- a/content/faq/1.1.md
+++ b/content/faq/1.1.md
@@ -759,7 +759,7 @@ information regarding your problem.</p>
 <h3><a name="boot"></a><a href="#toc">grml does not boot on my computer!</a></h3>
 
 <p>Please take a look at <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 available bootparamters and cheatcodes</a> and '<a href="#booting">Which
 ways exist to boot grml?</a>'. Especially booting with 'acpi=off noapm
 noapic' might help. Bootparameter 'failsafe' provides minimal hardware

--- a/content/faq/2008.11.md
+++ b/content/faq/2008.11.md
@@ -754,7 +754,7 @@ information regarding your problem.</p>
 <h3><a name="boot"></a><a href="#toc">grml does not boot on my computer!</a></h3>
 
 <p>Please take a look at <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 available bootparamters and cheatcodes</a> and '<a href="#booting">Which
 ways exist to boot grml?</a>'. Especially booting with 'acpi=off noapm
 noapic' might help. Bootparameter 'failsafe' provides minimal hardware

--- a/content/faq/2009.05.md
+++ b/content/faq/2009.05.md
@@ -228,7 +228,7 @@ common with Knoppix:</p>
 
 <p>We consider Knoppix as a brand name for live-cds nowadays and provide
 most of Knoppix' features as well. grml uses (mostly) the same <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">cheatcodes</a>
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">cheatcodes</a>
 for booting as Knoppix and even provides some extra ones. So if you are
 used to the basic Knoppix features you usually find them on the
 grml system as well.</p>
@@ -242,7 +242,7 @@ blind brltty=type,port,tbl') and flite.</p>
 <h3><a name="bootoptions"></a><a href="#toc#">Which bootoptions does grml support?</a></h3>
 
 <p>Check out the <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">grml-cheatcodes
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">grml-cheatcodes
 file</a> (available through the link titled 'grml-cheatcodes.txt' in the
 <a href="/files/#debian">Debian section on the files webpage</a>). Of
 course <a
@@ -416,7 +416,7 @@ information regarding your problem.</p>
 <h3><a name="boot"></a><a href="#toc">grml does not boot on my computer!</a></h3>
 
 <p>Please take a look at <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 available bootparamters and cheatcodes</a> and '<a href="#booting">Which
 ways exist to boot grml?</a>'. Especially booting with 'acpi=off noapm
 noapic' might help. The bootparameter 'failsafe' provides minimal

--- a/content/faq/2009.10.md
+++ b/content/faq/2009.10.md
@@ -230,7 +230,7 @@ common with Knoppix:</p>
 
 <p>We consider Knoppix as a brand name for live-cds nowadays and provide
 most of Knoppix' features as well. Grml uses (mostly) the same <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">cheatcodes</a>
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">cheatcodes</a>
 for booting as Knoppix and even provides some extra ones. So if you are
 used to the basic Knoppix features you usually find them on the
 grml system as well.</p>
@@ -244,7 +244,7 @@ blind brltty=type,port,tbl') and flite.</p>
 <h3><a name="bootoptions"></a><a href="#toc">Which bootoptions does Grml support?</a></h3>
 
 <p>Check out the <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">grml-cheatcodes
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">grml-cheatcodes
 file</a> (also available via <a href="/cheatcodes/">grml.org/cheatcodes/</a>). Of
 course <a
 href="http://www.kernel.org/doc/Documentation/kernel-parameters.txt">kernel-parameters.txt</a>
@@ -417,7 +417,7 @@ information regarding your problem.</p>
 <h3><a name="boot"></a><a href="#toc">grml does not boot on my computer!</a></h3>
 
 <p>Please take a look at <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 available bootparamters and cheatcodes</a> and '<a href="#booting">Which
 ways exist to boot grml?</a>'. Especially booting with 'acpi=off noapm
 noapic' might help. The bootparameter 'failsafe' provides minimal

--- a/content/faq/2010.04.md
+++ b/content/faq/2010.04.md
@@ -227,7 +227,7 @@ common with Knoppix:</p>
 
 <p>We consider Knoppix as a brand name for live-cds nowadays and provide
 most of Knoppix' features as well. Grml uses (mostly) the same <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">cheatcodes</a>
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">cheatcodes</a>
 for booting as Knoppix and even provides some extra ones. So if you are
 used to the basic Knoppix features you usually find them on the
 grml system as well.</p>
@@ -241,7 +241,7 @@ blind brltty=type,port,tbl') and flite.</p>
 <h3><a name="bootoptions"></a><a href="#toc">Which bootoptions does Grml support?</a></h3>
 
 <p>Check out the <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">grml-cheatcodes
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">grml-cheatcodes
 file</a> (also available via <a href="/cheatcodes/">grml.org/cheatcodes/</a>). Of
 course <a
 href="http://www.kernel.org/doc/Documentation/kernel-parameters.txt">kernel-parameters.txt</a>
@@ -413,7 +413,7 @@ information regarding your problem.</p>
 <h3><a name="boot"></a><a href="#toc">grml does not boot on my computer!</a></h3>
 
 <p>Please take a look at <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 available bootparamters and cheatcodes</a> and '<a href="#booting">Which
 ways exist to boot grml?</a>'. Especially booting with 'acpi=off noapm
 noapic' might help. The bootparameter 'failsafe' provides minimal

--- a/content/faq/2010.12.md
+++ b/content/faq/2010.12.md
@@ -225,7 +225,7 @@ common with Knoppix:</p>
 
 <p>We consider Knoppix as a brand name for live-cds nowadays and provide
 most of Knoppix' features as well. Grml uses (mostly) the same <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">cheatcodes</a>
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">cheatcodes</a>
 for booting as Knoppix and even provides some extra ones. So if you are
 used to the basic Knoppix features you usually find them on the
 grml system as well.</p>
@@ -239,7 +239,7 @@ blind brltty=type,port,tbl') and flite.</p>
 <h3><a name="bootoptions"></a><a href="#toc">Which bootoptions does Grml support?</a></h3>
 
 <p>Check out the <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">grml-cheatcodes
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">grml-cheatcodes
 file</a> (also available via <a href="/cheatcodes/">grml.org/cheatcodes/</a>). Of
 course <a
 href="http://www.kernel.org/doc/Documentation/kernel-parameters.txt">kernel-parameters.txt</a>
@@ -387,7 +387,7 @@ information regarding your problem.</p>
 <h3><a name="boot"></a><a href="#toc">grml does not boot on my computer!</a></h3>
 
 <p>Please take a look at <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 available bootparamters and cheatcodes</a> and '<a href="#booting">Which
 ways exist to boot grml?</a>'. Especially booting with 'acpi=off noapm
 noapic' might help. The bootparameter 'failsafe' provides minimal

--- a/content/faq/2011.05.md
+++ b/content/faq/2011.05.md
@@ -225,7 +225,7 @@ common with Knoppix:</p>
 
 <p>We consider Knoppix as a brand name for live-cds nowadays and provide
 most of Knoppix' features as well. Grml uses (mostly) the same <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">cheatcodes</a>
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">cheatcodes</a>
 for booting as Knoppix and even provides some extra ones. So if you are
 used to the basic Knoppix features you usually find them on the
 grml system as well.</p>
@@ -239,7 +239,7 @@ blind brltty=type,port,tbl') and flite.</p>
 <h3><a name="bootoptions"></a><a href="#toc">Which bootoptions does Grml support?</a></h3>
 
 <p>Check out the <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">grml-cheatcodes
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">grml-cheatcodes
 file</a> (also available via <a href="/cheatcodes/">grml.org/cheatcodes/</a>). Of
 course <a
 href="http://www.kernel.org/doc/Documentation/kernel-parameters.txt">kernel-parameters.txt</a>
@@ -392,7 +392,7 @@ information regarding your problem.</p>
 <h3><a name="boot"></a><a href="#toc">grml does not boot on my computer!</a></h3>
 
 <p>Please take a look at <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">the
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">the
 available bootparamters and cheatcodes</a> and '<a href="#booting">Which
 ways exist to boot grml?</a>'. Especially booting with 'acpi=off noapm
 noapic' might help. The bootparameter 'failsafe' provides minimal

--- a/content/faq/2012.05.md
+++ b/content/faq/2012.05.md
@@ -121,7 +121,7 @@ brltty and espeakup are included.</p>
 <h3><a name="bootoptions"></a><a href="#toc">Which bootoptions does Grml support?</a></h3>
 
 <p>Check out the <a
-href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">grml-cheatcodes
+href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">grml-cheatcodes
 file</a> (also available via <a href="/cheatcodes/">grml.org/cheatcodes/</a>). Of
 course <a
 href="http://www.kernel.org/doc/Documentation/kernel-parameters.txt">kernel-parameters.txt</a>

--- a/content/faq/_index.md
+++ b/content/faq/_index.md
@@ -135,7 +135,7 @@ For software, brltty and espeakup are included in grml-full.
 
 <h3><a name="bootoptions"></a><a href="#toc">Which boot options does Grml support?</a></h3>
 
-Check out the [grml-cheatcodes file](https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt) (also available via [grml.org/cheatcodes/](/cheatcodes/)).
+Check out the [grml-cheatcodes file](https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt) (also available via [grml.org/cheatcodes/](/cheatcodes/)).
 
 Of course [the command-line parameters](https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html) of the Linux kernel applies to Grml as well.
 

--- a/content/files/_index.md
+++ b/content/files/_index.md
@@ -80,7 +80,7 @@ sudo apt-get install grml-debian-keyring
 
 ## <a name="debian"></a>Package lists for the current release
 
-Boot options for all flavours: <a href="https://git.grml.org/f/grml-live/templates/GRML/grml-cheatcodes.txt">grml-cheatcodes.txt</a>
+Boot options for all flavours: <a href="https://git.grml.org/f/grml-live/config/media-files/GRMLBASE/GRML/GRML_NAME/grml-cheatcodes.txt">grml-cheatcodes.txt</a>
 
 {{< filelist.inline >}}
 {{ $current_version := $.Site.Params.current_release.version }}


### PR DESCRIPTION
The file got moved to a new place in
grml-live commit f0480b9ec312c853f370f3fca748a9aece7a1004

Thanks: Florian Geyer for the bug report
Closes: grml/grml-live#420