### PR TITLE
Improve handling of line breaks in monospace context

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -86,6 +86,7 @@ html{color:#000;background:#FFF}body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre
 @media screen {
   .active {background-color: #FFCC33}
   .rahmen {background-color: #FEDB64; padding: 5px; border: 1px dotted black}
+  pre {white-space-collapse: preserve; text-wrap-mode: wrap}
   abbr[title], acronym[title] {border-bottom: 1px dotted #333; cursor: help}
   #survey-header a { color: white; }
   #survey-header { background-color:#AE0000; color:#FFFFFF; font-family:sans-serif; font-size:120%; font-weight:bold; left:0; padding:5px 0; margin-bottom: 15px; position:fixed; text-align:center; top:0; width:100%; z-index:101; }


### PR DESCRIPTION
Before, pre was used with its annoying default behavior of overflowing content instead of breaking at white space line breaking opportunities.

Now, it is defined that white space inside a line is preserved (remember that HTML elements except `<pre>` collapse multiple whitespaces into a since space; so for `<pre>` we just make it explicit), but define wrapping behavior when it comes to breaking lines which is not the default for `<pre>`.

For the record: these CSS definitions do not destroy single-line commands when copying text, because visual line breaks are not represented in copied text.

This can be considered as lightweight fix to the terrible layout happening on mobile devices with long lines inside `<pre>` elements.