### PR TITLE
CSS: render footnotes properly

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -75,6 +75,9 @@ html{color:#000;background:#FFF}body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre
   i,em { font-style: italic }
   code,tt { font-family: "Ubuntu Mono", Consolas, Monaco, Courier, monospace }
   pre { background-color: lightgrey; font-family: "Ubuntu Mono", Consolas, Monaco, Courier, monospace; padding: .5rem 1rem; white-space-collapse: preserve; text-wrap-mode: wrap }
+  .footnotes { margin-top: 1em }
+  .footnotes ol { margin-left: 2em; padding-bottom: 0.3em }
+  .footnotes ol li { list-style: decimal }
   abbr[title], acronym[title] { border-bottom: 1px dotted #333; cursor: help }
   .long-hex-value { font-family: monospace; letter-spacing: -1px; overflow-wrap: anywhere }
   .active { background-color: #FFCC33 }

--- a/content/changelogs/README-grml-2025.12/index.md
+++ b/content/changelogs/README-grml-2025.12/index.md
@@ -38,7 +38,7 @@ New software since the Debian 13 release is included, and we continued to clean 
 
 Detailed changes: [grml-live v0.55.1 to v0.54.1](https://github.com/grml/grml-live/compare/v0.54.1...v0.55.1) [[^1]]
 
-[^1]: [1]: Note, that when comparing the changes between [grml-live v0.55.1 to v0.54.1](https://github.com/grml/grml-live/compare/v0.54.1...v0.55.1) it includes all commits from grml-desktop.
+[^1]: Note, that when comparing the changes between [grml-live v0.55.1 to v0.54.1](https://github.com/grml/grml-live/compare/v0.54.1...v0.55.1) it includes all commits from grml-desktop.
     To only list the changes from grml-live v0.55.1 to v0.54.1 use the following git command to exclude all commits which are pulled in from grml-desktop:
 
     `git log --oneline --no-merges v0.54.1..v0.55.1 ^83c27dcf`

--- a/content/changelogs/README-grml-2026.04/index.md
+++ b/content/changelogs/README-grml-2026.04/index.md
@@ -37,7 +37,7 @@ New software since the Grml 2025.12 release is included, and we continued to cle
 
 Detailed changes: [grml-live v0.55.1 to v0.56.0](https://github.com/grml/grml-live/compare/v0.55.1...v0.56.0) [[^1]]
 
-[^1]: [1]: Note, when comparing changes between [grml-live v0.55.1 and v0.56.0](https://github.com/grml/grml-live/compare/v0.55.1...v0.56.0) all commits from grml-scripts are included.
+[^1]: Note, when comparing changes between [grml-live v0.55.1 and v0.56.0](https://github.com/grml/grml-live/compare/v0.55.1...v0.56.0) all commits from grml-scripts are included.
     To list just the changes from grml-live v0.55.1 to v0.56.0, use the following command to exclude all grml-scripts commits created before grml-live v0.55.1 was released: `git log --oneline --no-merges --after "2025-12-11 18:41:18 +0100"`
 
 #### [grml-debootstrap](https://github.com/grml/grml-debootstrap) - Debian system install tool:


### PR DESCRIPTION
Hugo already produces HTML which should show a footnote number, but our CSS previously broke this. Set "list-style: decimal" for .footnotes to make the automatic thing work.